### PR TITLE
Allow `deps` scope in commit messages

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -21,4 +21,6 @@ policies:
           - "refactor"
           - "perf"
           - "test"
+        scopes:
+          - "deps"
         descriptionLength: 72


### PR DESCRIPTION
dependabot uses this scop in the commit messages and that makes sense. No need to reconfigure dependabot if we can just allow it.