### PR TITLE
Switch to markdownlint-cli2

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -20,7 +20,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Run mdl
-        uses: actionshub/markdownlint@main
+        uses: DavidAnson/markdownlint-cli2-action@v16
+        with:
+          globs: '**/*.md'
   lint-shellscripts:
     runs-on: ubuntu-latest
     steps:

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,10 @@
+gitignore: true
+
+config:
+  # MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
+  MD024:
+    # Only check sibling headings
+    siblings_only: true
+
+"$schema":
+  "https://raw.githubusercontent.com/DavidAnson/markdownlint-cli2/main/schema/markdownlint-cli2-config-schema.json"

--- a/README.md
+++ b/README.md
@@ -69,27 +69,27 @@ See [server readme](./api/README.md) for a hint on how to build a docker image.
   obviously)
 - Possible settings include
 
-   - Server to use
-   - Default room id
-   - username
-   - Some kind of "usertype", to distinguish "voter" vs "observer"
+  - Server to use
+  - Default room id
+  - username
+  - Some kind of "usertype", to distinguish "voter" vs "observer"
 
 - Written in golang or rust
 - There are some known libs from the golangiverse we could use:
 
-   - [tview](https://github.com/rivo/tview) for TUI
-   - [viper](https://github.com/spf13/viper) for configuration
+  - [tview](https://github.com/rivo/tview) for TUI
+  - [viper](https://github.com/spf13/viper) for configuration
 
 ## Meta
 
 - Go wild with commit hooks and linters:
 
-   - Markdown files
-   - Code files (eg. `detekt`, `ktlint`, for kotlin. No idea what the
-     golang/rust ppl do)
-      - Side project: create a native binary exe for detekt, since running jvm
-        stuff on every commit is the worst
-   - Commit msgs - enforce conventional commits
+  - Markdown files
+  - Code files (eg. `detekt`, `ktlint`, for kotlin. No idea what the
+    golang/rust ppl do)
+    - Side project: create a native binary exe for detekt, since running jvm
+      stuff on every commit is the worst
+  - Commit msgs - enforce conventional commits
 
 - Version numbers, release notes auto generated from landed commits.
 - Every commit should strive for perfection

--- a/api/README.md
+++ b/api/README.md
@@ -23,7 +23,7 @@ You can run the application in dev mode that enables live coding using:
 ./gradlew quarkusDev
 ```
 
-> **_NOTE:_**  Quarkus ships with a Dev UI, which is available in dev mode only
+> **NOTE:**  Quarkus ships with a Dev UI, which is available in dev mode only
 > at [localhost](http://localhost:8080/q/dev/).
 
 ## Packaging and running
@@ -35,19 +35,19 @@ The application can be packaged using:
 ```
 
 It produces the `quarkus-run.jar` file in the `build/quarkus-app/` directory.
-Be aware that it’s not an _über-jar_ as the dependencies are copied into the
+Be aware that it’s not an **über-jar** as the dependencies are copied into the
 `build/quarkus-app/lib/` directory.
 
 The application is now runnable using
 `java -jar build/quarkus-app/quarkus-run.jar`.
 
-If you want to build an _über-jar_, execute the following command:
+If you want to build an **über-jar**, execute the following command:
 
 ```shell script
 ./gradlew build -Dquarkus.package.type=uber-jar
 ```
 
-The application, packaged as an _über-jar_, is now runnable using
+The application, packaged as an **über-jar**, is now runnable using
 `java -jar build/*-runner.jar`.
 
 ## Creating a native executable

--- a/commit-hook.sh
+++ b/commit-hook.sh
@@ -15,9 +15,8 @@ fi
 git stash -q --keep-index --include-untracked
 
 # Lint markdown files
-git ls-files | grep ".*\.md$" | xargs docker run --rm \
-  -v "${PWD}":/data markdownlint/markdownlint
-MDL_RESULT=$?
+docker run -v "${PWD}":/workdir davidanson/markdownlint-cli2 "**/*.md"
+MD_RESULT=$?
 
 # Lint shell scripts
 git ls-files | grep ".*\.sh$" | xargs docker run --rm \
@@ -58,9 +57,9 @@ git stash pop -q
 
 # Check exit codes
 RED='\033[0;31m'
-if [ $MDL_RESULT -ne 0 ]; then
+if [ $MD_RESULT -ne 0 ]; then
     printf "%bCheck Failed for markdown\n" "${RED}"
-    exit $MDL_RESULT;
+    exit $MD_RESULT;
 elif [ $SHELLCHECK_RESULT -ne 0 ]; then
     printf "%bCheck Failed for shellcheck\n" "${RED}"
     exit $SHELLCHECK_RESULT;


### PR DESCRIPTION
The original markdownlint might be the OG, but is annoying to work with. Configuring the js alternative with yaml is much easier.