### PR TITLE
Update default server url

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -38,7 +38,7 @@ type config struct {
 }
 
 var defaultConfig = config{
-	ServerURL: "http://localhost:8080",
+	ServerURL: "https://pp.discordia.network",
 	RoomID:    "",
 	User:      "",
 }


### PR DESCRIPTION
We need an URL where we can actually reach the API without having to start one locally