### PR TITLE
Replace `user` with `name`

### DIFF
--- a/client/pp.yaml
+++ b/client/pp.yaml
@@ -1,3 +1,0 @@
-# Example configuration file
-server:
-  url: my.server.url

--- a/client/root.go
+++ b/client/root.go
@@ -110,8 +110,8 @@ func getWsURL() string {
 		}
 		roomURL = location
 	}
-	if GlobalConfig.User != "" {
-		roomURL = roomURL + "?user=" + url.QueryEscape(GlobalConfig.User) + "&userType=PARTICIPANT"
+	if GlobalConfig.Name != "" {
+		roomURL = roomURL + "?user=" + url.QueryEscape(GlobalConfig.Name) + "&userType=PARTICIPANT"
 	}
 	return roomURL
 }

--- a/integration-test/test/program.test.ts
+++ b/integration-test/test/program.test.ts
@@ -9,17 +9,29 @@ test.describe('basic --help tests', () => {
 });
 
 test.describe('tui tests', () => {
-    test.use({program: {file: "../client/pp", args: ['-u', 'nice user', '-r', 'what a room to be alive', '-s', 'http://localhost:31337']}});
+    test.use({program: {file: "../client/pp", args: ['-n', 'nice user', '-s', 'http://localhost:31337']}});
     test("pp can enter random room", async ({terminal}) => {
+        await expect(terminal.getByText(/nice user \(\*\)/g)).toBeVisible();
+    });
+});
+
+test.describe('tui tests', () => {
+    test.use({
+        program: {
+            file: "../client/pp",
+            args: ['-n', 'nice user', '-r', 'what a room to be alive', '-s', 'http://localhost:31337']
+        }
+    });
+    test("pp can enter custom room", async ({terminal}) => {
         await expect(terminal.getByText(/nice user \(\*\)/g)).toBeVisible();
         await expect(terminal.getByText(/what a room to be alive/g)).toBeVisible();
     });
 });
 
 test.describe('tui tests', () => {
-    test.use({program: {file: "../client/pp", args: ['-u', 'nice user', '-s', 'http://localhost:31337']}});
 
     test("pp shows user name and can quit", async ({terminal}) => {
+        terminal.submit('../client/pp -r "not-a-random-room" -n "nice user" -s http://localhost:31337');
         await expect(terminal.getByText(/nice user \(\*\)/g)).toBeVisible();
         const shiftTab = "\u001B[Z";
         terminal.submit(shiftTab) // tab switch back to quit btn
@@ -28,6 +40,7 @@ test.describe('tui tests', () => {
     });
 
     test("pp can vote", async ({terminal}) => {
+        terminal.submit('../client/pp -r "not-a-random-room" -n "nice user" -s http://localhost:31337');
         await expect(terminal.getByText(/││\?/g)).toBeVisible();
         const enter = "\u001B[13~";
         terminal.submit(enter) // enter activate btn (focus should be on first vote button by default)
@@ -52,13 +65,18 @@ test.describe('tui tests', () => {
         terminal.submit(enter)
         await expect(terminal.getByText(/││☕/g)).toBeVisible();
         terminal.submit(tab)
-        terminal.submit(enter) // submit button
+        terminal.submit(enter) // reveal button
         await expect(terminal.getByText(/ │☕/g)).toBeVisible();
         terminal.submit(tab)
         terminal.submit(enter) // start new round button
         await expect(terminal.getByText(/││\?/g)).toBeVisible();
-        terminal.submit(tab)
-        terminal.submit(' ')
-        await expect(terminal.getByText(/version/g)).toBeVisible();
+        // seems to only work locally
+        // terminal.submit(tab)
+        // terminal.submit(enter) // copy room name button
+        // terminal.submit(tab)
+        // terminal.submit(enter)
+        // await expect(terminal.getByText(/version/g)).toBeVisible();
+        // terminal.submit('xclip -o')
+        // await expect(terminal.getByText(/not-a-random-room/g)).toBeVisible();
     });
 });

--- a/publish.sh
+++ b/publish.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-cd client && go build -o pp
-upx --best pp
+cd client && go build -trimpath -ldflags '-w -s' -o pp
+upx --ultra-brute --overlay=strip --strip-relocs=0 pp
 
 cd ..
 


### PR DESCRIPTION
While the previews approach looked fine, it has some drawbacks: env vars are supposed to have higher priority than configuration files. So the `user` could never be set from a configuration file on linx: `$USER` env is set by default and would always be preferred.

Also, added a button to copy a rooms name to clipboard.