### PR TITLE
Users cannot play illegal cards anymore

### DIFF
--- a/api/src/main/kotlin/pp/api/RoomSocket.kt
+++ b/api/src/main/kotlin/pp/api/RoomSocket.kt
@@ -1,6 +1,6 @@
 package pp.api
 
-import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.core.JacksonException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.quarkus.logging.Log
@@ -70,7 +70,7 @@ class RoomSocket(
         try {
             val request: UserRequest = mapper.readValue(message)
             rooms.submitUserRequest(request, session)
-        } catch (e: JsonParseException) {
+        } catch (e: JacksonException) {
             Log.error("Failed to parse message: $message", e)
         }
     }

--- a/api/src/main/kotlin/pp/api/Rooms.kt
+++ b/api/src/main/kotlin/pp/api/Rooms.kt
@@ -176,11 +176,15 @@ class Rooms {
         }
     }
 
-    private fun playCard(session: Session, cardValue: String) {
+    private fun playCard(session: Session, cardValue: String?) {
         get(session)?.let { (room, user) ->
             if (room.gamePhase == PLAYING) {
-                val updatedUser = user.copy(cardValue = cardValue)
-                update((room - session) withUser updatedUser)
+                if (cardValue != null && cardValue !in room.deck) {
+                    update(room withInfo "${user.username} tried to play card with illegal value: $cardValue")
+                } else {
+                    val updatedUser = user.copy(cardValue = cardValue)
+                    update((room - session) withUser updatedUser)
+                }
             } else {
                 update(room withInfo "${user.username} tried to play card while no round was in progress")
             }

--- a/api/src/main/kotlin/pp/api/data/UserRequest.kt
+++ b/api/src/main/kotlin/pp/api/data/UserRequest.kt
@@ -77,7 +77,7 @@ sealed class UserRequest(
  *   The card value to play
  */
 data class PlayCard(
-    val cardValue: String,
+    val cardValue: String?,
 ) : UserRequest(PLAY_CARD)
 
 /**

--- a/api/src/test/kotlin/pp/api/RoomsTest.kt
+++ b/api/src/test/kotlin/pp/api/RoomsTest.kt
@@ -155,7 +155,7 @@ class RoomsTest {
     }
 
     @Test
-    fun submitUserRequestPlayCard() {
+    fun submitUserRequestIllegalPlayCard() {
         val rooms = Rooms()
         val remote = mock(Async::class.java)
         val session = mock(Session::class.java)
@@ -171,7 +171,56 @@ class RoomsTest {
         )
         rooms.submitUserRequest(PlayCard("19"), session)
         assertEquals(
-            "19", rooms.getRooms().first().users
+            null, rooms.getRooms().first().users
+                .first().cardValue
+        )
+    }
+
+    @Test
+    fun submitUserRequestLegalPlayCard() {
+        val rooms = Rooms()
+        val remote = mock(Async::class.java)
+        val session = mock(Session::class.java)
+        whenever(session.asyncRemote).thenReturn(remote)
+        whenever(remote.sendObject(any())).thenReturn(constantFuture(null))
+        val user = User("username", SPECTATOR, null, session)
+        whenever(session.id).thenReturn("new-session-id")
+        rooms.ensureRoomContainsUser("nice-id", user)
+
+        assertNull(
+            rooms.getRooms().first().users
+                .first().cardValue
+        )
+        rooms.submitUserRequest(PlayCard("5"), session)
+        assertEquals(
+            "5", rooms.getRooms().first().users
+                .first().cardValue
+        )
+    }
+
+    @Test
+    fun submitUserRequestResetCard() {
+        val rooms = Rooms()
+        val remote = mock(Async::class.java)
+        val session = mock(Session::class.java)
+        whenever(session.asyncRemote).thenReturn(remote)
+        whenever(remote.sendObject(any())).thenReturn(constantFuture(null))
+        val user = User("username", SPECTATOR, null, session)
+        whenever(session.id).thenReturn("new-session-id")
+        rooms.ensureRoomContainsUser("nice-id", user)
+
+        assertNull(
+            rooms.getRooms().first().users
+                .first().cardValue
+        )
+        rooms.submitUserRequest(PlayCard("5"), session)
+        assertEquals(
+            "5", rooms.getRooms().first().users
+                .first().cardValue
+        )
+        rooms.submitUserRequest(PlayCard(null), session)
+        assertEquals(
+            null, rooms.getRooms().first().users
                 .first().cardValue
         )
     }
@@ -191,7 +240,7 @@ class RoomsTest {
             rooms.getRooms().first().users
                 .first().cardValue
         )
-        rooms.submitUserRequest(PlayCard("19"), session)
+        rooms.submitUserRequest(PlayCard("3"), session)
 
         val unknownSession = mock(Session::class.java)
         whenever(unknownSession.id).thenReturn("unknown-session-id")
@@ -202,7 +251,7 @@ class RoomsTest {
                 .first().username
         )
         assertEquals(
-            "19", rooms.getRooms().first().users
+            "3", rooms.getRooms().first().users
                 .first().cardValue
         )
     }
@@ -368,9 +417,9 @@ class RoomsTest {
             rooms.getRooms().first().users
                 .first().cardValue
         )
-        rooms.submitUserRequest(PlayCard("19"), session)
+        rooms.submitUserRequest(PlayCard("5"), session)
         assertEquals(
-            "19", rooms.getRooms().first().users
+            "5", rooms.getRooms().first().users
                 .first().cardValue
         )
     }


### PR DESCRIPTION
Card value of dto `PlayCard` was not checked against the rooms deck. Now it is.

We also allow players to play a null value card, resetting their vote.