### PR TITLE
Remove misleading log messages

### DIFF
--- a/api/src/main/kotlin/pp/api/Rooms.kt
+++ b/api/src/main/kotlin/pp/api/Rooms.kt
@@ -50,7 +50,7 @@ class Rooms {
             Log.info("Creating room $roomId")
             Room(roomId)
         }
-        update(room withUser user)
+        update(room withUser user withInfo "User ${user.username} joined")
     }
 
     /**
@@ -171,8 +171,9 @@ class Rooms {
 
     private fun changeName(session: Session, name: String) {
         get(session)?.let { (room, user) ->
-            val updatedUser = user.copy(username = name)
-            update((room - session) withUser updatedUser)
+            val updatedRoom = room withInfo "User ${user.username} changed name to $name"
+            user.username = name
+            update(updatedRoom)
         }
     }
 
@@ -182,8 +183,8 @@ class Rooms {
                 if (cardValue != null && cardValue !in room.deck) {
                     update(room withInfo "${user.username} tried to play card with illegal value: $cardValue")
                 } else {
-                    val updatedUser = user.copy(cardValue = cardValue)
-                    update((room - session) withUser updatedUser)
+                    user.cardValue = cardValue
+                    update(room)
                 }
             } else {
                 update(room withInfo "${user.username} tried to play card while no round was in progress")
@@ -219,7 +220,8 @@ class Rooms {
                         }
                     )
                 }
-                update(updatedRoom)
+                val message = if (newGamePhase == CARDS_REVEALED) "revealed the cards" else "started a new round"
+                update(updatedRoom withInfo "${user.username} $message}")
             } else {
                 val error = "${user.username} tried to change game phase to $newGamePhase, but that's illegal"
                 update(room withInfo error)

--- a/api/src/main/kotlin/pp/api/data/User.kt
+++ b/api/src/main/kotlin/pp/api/data/User.kt
@@ -777,9 +777,9 @@ private val funnyNames = listOf(
  * @property connectionDeadline
  */
 data class User(
-    val username: String,
-    val userType: UserType,
-    val cardValue: String?,
+    var username: String,
+    var userType: UserType,
+    var cardValue: String?,
     val session: Session,
     var connectionDeadline: LocalTime = threeMinutesFromNow(),
 ) {

--- a/api/src/test/kotlin/pp/api/RoomsTest.kt
+++ b/api/src/test/kotlin/pp/api/RoomsTest.kt
@@ -268,17 +268,16 @@ class RoomsTest {
         rooms.ensureRoomContainsUser("nice-id", user)
 
         assertEquals(
-            0, rooms.getRooms().first().log
+            1, rooms.getRooms().first().log
                 .size
         )
         rooms.submitUserRequest(ChatMessage("nice message"), session)
         assertEquals(
-            1, rooms.getRooms().first().log
+            2, rooms.getRooms().first().log
                 .size
         )
         assertEquals(
-            LogEntry(CHAT, "[interesting user]: nice message"), rooms.getRooms().first().log
-                .first()
+            LogEntry(CHAT, "[interesting user]: nice message"), rooms.getRooms().first().log[1]
         )
     }
 
@@ -294,12 +293,12 @@ class RoomsTest {
         rooms.ensureRoomContainsUser("nice-id", user)
 
         assertEquals(
-            0, rooms.getRooms().first().log
+            1, rooms.getRooms().first().log
                 .size
         )
         rooms.submitUserRequest(ChatMessage(""), session)
         assertEquals(
-            0, rooms.getRooms().first().log
+            1, rooms.getRooms().first().log
                 .size
         )
     }
@@ -317,12 +316,12 @@ class RoomsTest {
         val unknownSession = mock(Session::class.java)
         whenever(unknownSession.id).thenReturn("unknown-session-id")
         assertEquals(
-            0, rooms.getRooms().first().log
+            1, rooms.getRooms().first().log
                 .size
         )
         rooms.submitUserRequest(ChatMessage("nice message"), unknownSession)
         assertEquals(
-            0, rooms.getRooms().first().log
+            1, rooms.getRooms().first().log
                 .size
         )
     }
@@ -374,11 +373,11 @@ class RoomsTest {
         rooms.submitUserRequest(RevealCards(), session)
         assertEquals(CARDS_REVEALED, rooms.getRooms().first().gamePhase)
         assertEquals(
-            1, rooms.getRooms().first().log
+            3, rooms.getRooms().first().log
                 .size
         )
         assertTrue(rooms.getRooms().first().log
-            .all { it.level == INFO && "tried to change game phase" in it.message })
+            .any { it.level == INFO && "tried to change game phase" in it.message })
     }
 
     @Test
@@ -442,11 +441,11 @@ class RoomsTest {
                 .first().cardValue
         )
         assertEquals(
-            1, rooms.getRooms().first().log
+            2, rooms.getRooms().first().log
                 .size
         )
         assertTrue(rooms.getRooms().first().log
-            .all { it.level == INFO && "tried to change game phase" in it.message })
+            .any { it.level == INFO && "tried to change game phase" in it.message })
     }
 
     @Test
@@ -471,10 +470,14 @@ class RoomsTest {
 
         rooms.sendPings()
 
-        assertEquals(1, rooms.getRooms().first().users
-            .size)
-        assertEquals(nonErrorUser.username, rooms.getRooms().first().users
-            .first().username)
+        assertEquals(
+            1, rooms.getRooms().first().users
+                .size
+        )
+        assertEquals(
+            nonErrorUser.username, rooms.getRooms().first().users
+                .first().username
+        )
     }
 
     @Test
@@ -499,8 +502,10 @@ class RoomsTest {
         rooms.ensureRoomContainsUser("nice-id", timeoutUser)
         rooms.removeUnresponsiveUsers()
         assertEquals(1, rooms.getRooms().size)
-        assertEquals(normalUser.username, rooms.getRooms().first().users
-            .first().username)
+        assertEquals(
+            normalUser.username, rooms.getRooms().first().users
+                .first().username
+        )
     }
 
     @Test
@@ -516,8 +521,10 @@ class RoomsTest {
 
         rooms.ensureRoomContainsUser("nice-id", normalUser)
         rooms.resetUserConnectionDeadline(session)
-        assertTrue(rooms.getRooms().first().users
-            .first().connectionDeadline > now.plusMinutes(3))
+        assertTrue(
+            rooms.getRooms().first().users
+                .first().connectionDeadline > now.plusMinutes(3)
+        )
 
         // Now lets get that juicy 100% branch coverage on this method ;)
         val unknownSession = mock(Session::class.java)


### PR DESCRIPTION
Since users were immutable, they were removed and added an any change (playing card, or updating name).

name and card of a user are now mutable and can be update "in place", leading to less misleading messages.