### PR TITLE
fix: removes upx from github action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,10 +34,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install UPX
-        uses: crazy-max/ghaction-upx@v3
-        with:
-          install-only: true
       - name: setup ssh
         run: |
           mkdir -p ~/.ssh


### PR DESCRIPTION
This is a `fix` because we need to trigger a build